### PR TITLE
Fix: Refactor dashboard components to use lazy loading

### DIFF
--- a/resources/js/Pages/Admin/Dashboard.vue
+++ b/resources/js/Pages/Admin/Dashboard.vue
@@ -25,26 +25,26 @@
                 </div>
 
                 <!-- Statistics Grid -->
-                <StatsGrid :stats="safeStats" />
+                <LazyDashboardComponents.StatsGrid :stats="safeStats" />
 
                 <!-- Main Content Grid -->
                 <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
                     <!-- Recent Activity -->
-                    <RecentActivity 
-                        :activities="recentActivities" 
+                    <LazyDashboardComponents.RecentActivity
+                        :activities="recentActivities"
                         @refresh="refreshActivities"
                     />
 
                     <!-- System Health -->
-                    <SystemHealth 
-                        :health="systemHealth" 
+                    <LazyDashboardComponents.SystemHealth
+                        :health="systemHealth"
                         @refresh="refreshSystemHealth"
                         @view-error="viewErrorDetails"
                     />
                 </div>
 
                 <!-- Checker Management -->
-                <CheckerManagement 
+                <LazyDashboardComponents.CheckerManagement
                     :checkers="checkers"
                     @refresh="refreshCheckers"
                     @create="createChecker"
@@ -133,10 +133,7 @@ import { Head, Link, router } from "@inertiajs/vue3";
 import { onMounted, computed, ref } from 'vue';
 import ErrorBoundary from '@/Components/ErrorBoundary.vue';
 import LoadingSpinner from '@/Components/LoadingSpinner.vue';
-import StatsGrid from '@/Components/Admin/StatsGrid.vue';
-import RecentActivity from '@/Components/Admin/RecentActivity.vue';
-import CheckerManagement from '@/Components/Admin/CheckerManagement.vue';
-import SystemHealth from '@/Components/Admin/SystemHealth.vue';
+import { LazyDashboardComponents } from '@/utils/lazyLoading';
 import { validateStats, validateMissions, validateAndFormatDate } from '@/utils/dataValidation';
 
 const props = defineProps({

--- a/resources/js/Pages/Checker/Dashboard.vue
+++ b/resources/js/Pages/Checker/Dashboard.vue
@@ -34,20 +34,20 @@
         <div class="py-3 sm:py-4 lg:py-6">
             <div class="max-w-7xl mx-auto px-3 sm:px-4 lg:px-6 space-y-3 sm:space-y-4 lg:space-y-6">
                 <!-- Urgent Missions Component -->
-                <UrgentMissions 
+                <LazyDashboardComponents.UrgentMissions
                     v-if="urgentMissions.length > 0"
                     :missions="urgentMissions"
                     @start-mission="handleStartMission"
                 />
 
                 <!-- Statistics Cards Component -->
-                <StatsCards :stats="dashboardStats" />
+                <LazyDashboardComponents.StatsCards :stats="dashboardStats" />
 
                 <!-- Main Content Grid - Mobile-first responsive -->
                 <div class="grid grid-cols-1 xl:grid-cols-3 gap-3 sm:gap-4 lg:gap-6">
                     <!-- Today's Schedule Component -->
                     <div class="xl:col-span-2 order-2 xl:order-1">
-                        <TodaySchedule 
+                        <LazyDashboardComponents.TodaySchedule
                             :missions="getTodaySchedule()"
                             @start-mission="handleStartMission"
                             @navigate-to-mission="handleNavigateToMission"
@@ -57,7 +57,7 @@
                     <!-- Quick Actions & Weekly Performance -->
                     <div class="space-y-3 sm:space-y-4 order-1 xl:order-2">
                         <!-- Quick Actions Component -->
-                        <QuickActions 
+                        <LazyDashboardComponents.QuickActions
                             :stats="quickActionStats"
                             @open-camera="handleOpenCamera"
                             @call-support="handleCallSupport"
@@ -206,11 +206,8 @@ import { Head, Link, router } from '@inertiajs/vue3';
 import { computed, ref, onMounted, onUnmounted } from 'vue';
 import ErrorBoundary from '@/Components/ErrorBoundary.vue';
 import LoadingSpinner from '@/Components/LoadingSpinner.vue';
-import UrgentMissions from '@/Components/Checker/UrgentMissions.vue';
-import StatsCards from '@/Components/Checker/StatsCards.vue';
-import TodaySchedule from '@/Components/Checker/TodaySchedule.vue';
-import QuickActions from '@/Components/Checker/QuickActions.vue';
 import OfflineService from '@/Services/OfflineService.js';
+import { LazyDashboardComponents } from '@/utils/lazyLoading';
 
 const props = defineProps({
     assignedMissions: {

--- a/resources/js/Pages/Ops/Dashboard.vue
+++ b/resources/js/Pages/Ops/Dashboard.vue
@@ -173,7 +173,7 @@
 
                     <!-- Overview View -->
                     <div v-if="currentView === 'overview'">
-                        <OverviewStats
+                        <LazyDashboardComponents.OverviewStats
                             :metrics="metrics"
                             :recent-activities="recentActivities"
                             :today-missions="todayMissions"
@@ -184,7 +184,7 @@
 
                     <!-- Kanban View -->
                     <div v-if="currentView === 'kanban'" class="space-y-6">
-                        <KanbanBoard
+                        <LazyDashboardComponents.KanbanBoard
                             :items="kanbanData"
                             :loading="loading"
                             @drop="handleKanbanDrop"
@@ -195,7 +195,7 @@
 
                     <!-- Analytics View -->
                     <div v-if="currentView === 'analytics'" class="space-y-6">
-                        <AnalyticsView
+                        <LazyDashboardComponents.AnalyticsView
                             :data="{
                                 metrics,
                                 trends: performanceTrends,
@@ -217,13 +217,10 @@ import { ref, reactive, onMounted, computed } from 'vue'
 import ErrorBoundary from '@/Components/ErrorBoundary.vue'
 import LoadingSpinner from '@/Components/LoadingSpinner.vue'
 import DashboardOps from '@/Layouts/DashboardOps.vue'
-import NotificationPanel from '@/Components/NotificationPanel.vue'
 import BailMobiliteCard from '@/Components/BailMobiliteCard.vue'
 import PrimaryButton from '@/Components/PrimaryButton.vue'
 import SecondaryButton from '@/Components/SecondaryButton.vue'
-import KanbanBoard from '@/Components/KanbanBoard.vue'
-import OverviewStats from '@/Components/OverviewStats.vue'
-import AnalyticsView from '@/Components/AnalyticsView.vue'
+import { LazyDashboardComponents } from '@/utils/lazyLoading'
 // Simple debounce function
 const debounce = (func, wait) => {
     let timeout


### PR DESCRIPTION
Refactored the Admin, Ops, and Checker dashboard pages to correctly use the `LazyDashboardComponents` utility.

The application was experiencing a blank page issue because the dashboard components were being imported synchronously, which conflicted with the existing lazy loading setup in `resources/js/utils/lazyLoading.js`. This likely caused an issue in Vite's dependency resolution, leading to the application failing to render.

This change corrects the issue by:
- Removing the static, synchronous imports from the dashboard page components (`Admin/Dashboard.vue`, `Ops/Dashboard.vue`, `Checker/Dashboard.vue`).
- Updating the templates to use the corresponding asynchronous components from the `LazyDashboardComponents` object.

This aligns the components with the intended lazy-loading architecture and should resolve the blank page and import errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Optimized Admin, Checker, and Ops dashboards to load components on demand, reducing initial load times and improving responsiveness.
  - Unified component loading to streamline rendering across dashboard views without changing functionality.
  - Enhances perceived performance during navigation and lowers resource usage on first load.
  - No changes to user workflows or data; visuals and behavior remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->